### PR TITLE
Add simple PWA skeleton with backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+frontend/node_modules/
+backend/node_modules/
+dist/
+.env

--- a/README.md
+++ b/README.md
@@ -61,7 +61,19 @@ npm run dev
 
 4. Backend Setup
 
-Refer to /server/README.md for full backend setup.
+```
+cd backend
+npm install
+npm start
+```
+
+5. Frontend Setup
+
+```
+cd frontend
+npm install
+npm run dev
+```
 
 🔐 Authentication
 
@@ -72,16 +84,16 @@ Token-based login flow with route guards.
 🗃 Directory Structure
 
 .
-├── public/
-│   └── index.html
-├── src/
-│   ├── App.js
-│   ├── components/
-│   ├── screens/
-│   └── api/
+├── frontend/
+│   ├── public/
+│   │   └── index.html
+│   └── src/
+│       ├── App.jsx
+│       ├── components/
+│       ├── screens/
+│       └── api/
 ├── backend/
-│   ├── server.js
-│   └── db/
+│   └── server.js
 
 📄 Role Docs
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pharma-backend",
+  "version": "0.1.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,81 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// In-memory data
+let products = [
+  { id: 1, name: 'Aspirin', batch: 'A1', expiry: '2025-12-31' },
+  { id: 2, name: 'Paracetamol', batch: 'P1', expiry: '2024-10-31' }
+];
+let orders = [];
+let inboundOrders = [];
+let dispatchOrders = [];
+
+// Manufacturer endpoints
+app.get('/api/products', (req, res) => {
+  res.json(products);
+});
+
+app.post('/api/products', (req, res) => {
+  const product = { id: Date.now(), ...req.body };
+  products.push(product);
+  res.status(201).json(product);
+});
+
+// CFA endpoints
+app.get('/api/inbound-orders', (req, res) => {
+  res.json(inboundOrders);
+});
+
+app.patch('/api/inbound-orders/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const order = inboundOrders.find(o => o.id === id);
+  if (!order) return res.status(404).json({ message: 'Order not found' });
+  order.status = 'received';
+  res.json(order);
+});
+
+app.get('/api/dispatch-orders', (req, res) => {
+  res.json(dispatchOrders);
+});
+
+app.post('/api/dispatch-orders', (req, res) => {
+  const order = { id: Date.now(), ...req.body };
+  dispatchOrders.push(order);
+  res.status(201).json(order);
+});
+
+// Stockist endpoints
+app.get('/api/products/available', (req, res) => {
+  res.json(products);
+});
+
+app.post('/api/orders', (req, res) => {
+  const order = { id: Date.now(), ...req.body };
+  orders.push(order);
+  res.status(201).json(order);
+});
+
+app.get('/api/orders', (req, res) => {
+  res.json(orders);
+});
+
+app.patch('/api/shipments/:id', (req, res) => {
+  const shipment = dispatchOrders.find(o => o.id === Number(req.params.id));
+  if (!shipment) return res.status(404).json({ message: 'Shipment not found' });
+  shipment.status = 'acknowledged';
+  res.json(shipment);
+});
+
+app.get('/api/stock', (req, res) => {
+  res.json(products);
+});
+
+// Start server
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Backend running on port ${PORT}`);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pharma-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.1"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.0.3"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pharma Supply Chain App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,0 +1,11 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('pharma-cache-v1').then(cache => cache.add('/'))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import ManufacturerDashboard from './screens/ManufacturerDashboard.jsx';
+import CFADashboard from './screens/CFADashboard.jsx';
+import StockistDashboard from './screens/StockistDashboard.jsx';
+
+export default function App() {
+  return (
+    <div>
+      <nav>
+        <Link to="/manufacturer">Manufacturer</Link> |{' '}
+        <Link to="/cfa">CFA</Link> |{' '}
+        <Link to="/stockist">Stockist</Link>
+      </nav>
+      <Routes>
+        <Route path="/manufacturer" element={<ManufacturerDashboard />} />
+        <Route path="/cfa" element={<CFADashboard />} />
+        <Route path="/stockist" element={<StockistDashboard />} />
+        <Route path="*" element={<p>Select role</p>} />
+      </Routes>
+    </div>
+  );
+}

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,0 +1,16 @@
+const BASE_URL = 'http://localhost:3001/api';
+
+export async function listProducts() {
+  const res = await fetch(`${BASE_URL}/products`);
+  return res.json();
+}
+
+export async function listInboundOrders() {
+  const res = await fetch(`${BASE_URL}/inbound-orders`);
+  return res.json();
+}
+
+export async function listAvailableProducts() {
+  const res = await fetch(`${BASE_URL}/products/available`);
+  return res.json();
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}

--- a/frontend/src/screens/CFADashboard.jsx
+++ b/frontend/src/screens/CFADashboard.jsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+import { listInboundOrders } from '../api';
+
+export default function CFADashboard() {
+  const [orders, setOrders] = useState([]);
+  useEffect(() => {
+    listInboundOrders().then(setOrders);
+  }, []);
+  return (
+    <div>
+      <h1>CFA Dashboard</h1>
+      <ul>
+        {orders.map(o => (
+          <li key={o.id}>{o.product} - {o.status}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/screens/ManufacturerDashboard.jsx
+++ b/frontend/src/screens/ManufacturerDashboard.jsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+import { listProducts } from '../api';
+
+export default function ManufacturerDashboard() {
+  const [products, setProducts] = useState([]);
+  useEffect(() => {
+    listProducts().then(setProducts);
+  }, []);
+  return (
+    <div>
+      <h1>Manufacturer Dashboard</h1>
+      <ul>
+        {products.map(p => (
+          <li key={p.id}>{p.name} - Batch {p.batch}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/screens/StockistDashboard.jsx
+++ b/frontend/src/screens/StockistDashboard.jsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+import { listAvailableProducts } from '../api';
+
+export default function StockistDashboard() {
+  const [products, setProducts] = useState([]);
+  useEffect(() => {
+    listAvailableProducts().then(setProducts);
+  }, []);
+  return (
+    <div>
+      <h1>Stockist Dashboard</h1>
+      <ul>
+        {products.map(p => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- create backend Express server with placeholder endpoints
- scaffold frontend React PWA using Vite
- add simple screens and service worker
- document backend/frontend setup steps

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684982512754832aabd9c17effd07a2c