### PR TITLE
Improve frontend config for remote backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ npm install
 npm run dev
 ```
 
+By default the frontend assumes the backend runs on the same host on port `3001`.
+If your backend is hosted elsewhere, create a `.env` file in `frontend/` with:
+
+```
+VITE_BACKEND_URL=http://<backend-ip>:3001/api
+```
+
+Then restart the dev server.
+
 🔐 Authentication
 
 Each user has a role: manufacturer, cfa, or stockist.

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,5 +1,13 @@
 let BASE_URL = 'http://localhost:3001/api';
 
+// Allow overriding via Vite environment variable. When running in a browser
+// without a specified variable, default to the backend on the current host.
+if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_BACKEND_URL) {
+  BASE_URL = import.meta.env.VITE_BACKEND_URL;
+} else if (typeof window !== 'undefined') {
+  BASE_URL = `http://${window.location.hostname}:3001/api`;
+}
+
 export function setBaseUrl(url) {
   BASE_URL = url;
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: true, // listen on all addresses so the app can be reached via the backend IP
   },
 });


### PR DESCRIPTION
## Summary
- configure Vite dev server to bind on all interfaces
- allow API base URL to come from `VITE_BACKEND_URL` or current host
- document how to run frontend against a remote backend

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684989353110832aabccb35ba91afe33