### PR TITLE
Update frontend for IP-based backend access

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,13 @@ npm start
 ```
 cd frontend
 npm install
-npm run dev
+npm run dev -- --host
 ```
+
+The frontend automatically points to the backend running on the same host. When
+accessing the app via the backend's IP address, API requests will be sent to
+`http://<backend-ip>:3001`. If you need to override this behaviour, set
+`VITE_BACKEND_URL` in `frontend/.env` and restart the dev server.
 
 🔐 Authentication
 

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,4 +1,11 @@
-let BASE_URL = 'http://localhost:3001/api';
+let BASE_URL;
+
+if (typeof window !== 'undefined') {
+  const host = window.location.hostname;
+  BASE_URL = `http://${host}:3001/api`;
+} else {
+  BASE_URL = 'http://localhost:3001/api';
+}
 
 export function setBaseUrl(url) {
   BASE_URL = url;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: true,
   },
 });


### PR DESCRIPTION
## Summary
- enable host IP detection in API helper
- allow Vite dev server to listen on network interfaces
- document how to run the frontend against backend IP

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684989308428832aa272c1720658e7e6